### PR TITLE
Add typedefs for PocketArticle schema

### DIFF
--- a/packages/gatsby-theme-pocket/gatsby-node.js
+++ b/packages/gatsby-theme-pocket/gatsby-node.js
@@ -1,9 +1,30 @@
 exports.createPages = async ({ actions: { createPage } }, pluginOptions) => {
-
-    if (pluginOptions.customUrl) {
-        createPage({
-            path: `/${pluginOptions.customUrl}/`,
-            component: require.resolve('./src/templates/articlesTemplate.js')
-        })
-    }
+  if (pluginOptions.customUrl) {
+    createPage({
+      path: `/${pluginOptions.customUrl}/`,
+      component: require.resolve("./src/templates/articlesTemplate.js"),
+    });
   }
+};
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+  const typeDefs = `
+      type PocketArticle implements Node {
+        tags: [String],
+        excerpt: String,
+        title: String,
+        image: Image,
+        url: String, 
+        time_added: String,
+      }
+
+      type Image {
+        height: String,
+        item_id: String,
+        src: String,
+        width: String
+      }
+    `;
+  createTypes(typeDefs);
+};


### PR DESCRIPTION
This resolves `#2` from https://github.com/molebox/gatsby-theme-pocket/issues/11

I noticed there are several more fields than what was originally mentioned in the issue that if non-existent across every article, will break the GraphQL query at build time. 

[Gatsby documentation](https://www.gatsbyjs.com/docs/schema-customization/#fixing-field-types) for the fix.